### PR TITLE
Fix node config extension

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: [
-    './index',
+    './rules/base',
+    './rules/imports',
     './rules/node',
   ].map(require.resolve),
 


### PR DESCRIPTION
problem: `node` config requires `index` and `index` required `react`, which makes node depends on react plugin